### PR TITLE
Fix bugs in Vagrantfile and test.py

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,7 +94,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # share to a temporary location and the provisioning scripts symlink data
       # to the right location.
       config.cache.enable :generic, {
-        "oracle-jdk7" => { cache_dir: "/tmp/oracle-jdk7-installer-cache" },
+        "oracle-jdk6" => { cache_dir: "/tmp/oracle-jdk6-installer-cache" },
       }
     end
   end

--- a/muckrake/tests/test.py
+++ b/muckrake/tests/test.py
@@ -49,7 +49,6 @@ class KafkaTest(Test):
         self.kafka = KafkaService(
             ServiceContext(self.cluster, self.num_brokers, self.logger),
             self.zk, topics=self.topics)
-        print "kafka: ", str(self.kafka)
         self.zk.start()
         self.kafka.start()
 


### PR DESCRIPTION
@granders @ewencp Addressed some issues when setting up the Kafka scripts. 
1. Vagrant cache is not setup correctly as muckrake is using jdk6.
2. Remove unnecessary print statement in KafkaTest.   