### PR TITLE
java 6 -> java 7

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -94,7 +94,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
       # share to a temporary location and the provisioning scripts symlink data
       # to the right location.
       config.cache.enable :generic, {
-        "oracle-jdk6" => { cache_dir: "/tmp/oracle-jdk6-installer-cache" },
+        "oracle-jdk7" => { cache_dir: "/tmp/oracle-jdk7-installer-cache" },
       }
     end
   end

--- a/aws/aws-init.sh
+++ b/aws/aws-init.sh
@@ -3,11 +3,31 @@
 # This script should be run once on your aws test driver machine before
 # attempting to run any ducktape tests
 
-# Install dependencies
-sudo apt-get install -y maven openjdk-6-jdk build-essential \
-            ruby-dev zlib1g-dev realpath python-setuptools
+while [[ $# > 0 ]]
+do
+key="$1"
+
+case $key in
+    --jdk)
+        jdk="$2"
+        shift # past argument
+        ;;
+    *)
+        # unknown option
+        ;;
+esac
+shift # past argument or value
+done
 
 base_dir=`dirname $0`/..
+if [ -z $jdk ]; then
+    jdk=7
+    echo "using default jdk: $jdk"
+fi
+
+# Install dependencies
+sudo apt-get install -y maven openjdk-$jdk-jdk build-essential \
+            ruby-dev zlib1g-dev realpath python-setuptools
 
 if [ -z `which vagrant` ]; then
     echo "Installing vagrant..."

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ fi
 # Detect jdk version
 jdk=`javac -version 2>&1 | cut -d ' ' -f 2`
 ver=`echo $jdk | cut -d '.' -f 2`
-if (( $ver > 6 )); then
+if (( $ver > 7 )); then
     echo "Found jdk version $jdk"
-    echo "You should only build with jdk 1.6 or below."
+    echo "You should only build with jdk 1.7 or below."
     exit 1
 fi
 
@@ -35,7 +35,7 @@ done
 
 # Default JAVA_HOME for EC2
 if [ -z "$JAVA_HOME" ]; then
-    export JAVA_HOME=/usr/lib/jvm/java-6-openjdk-amd64
+    export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64
 fi
 
 # Default gradle for local gradle download, e.g. on EC2

--- a/muckrake/defaults.py
+++ b/muckrake/defaults.py
@@ -1,0 +1,18 @@
+# Copyright 2015 Confluent Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared defaults"""
+
+
+DEFAULT_JDK = 7

--- a/muckrake/services/templates/cdh/yarn-env.sh
+++ b/muckrake/services/templates/cdh/yarn-env.sh
@@ -20,7 +20,6 @@ export HADOOP_YARN_USER=${HADOOP_YARN_USER:-yarn}
 export YARN_CONF_DIR="${YARN_CONF_DIR:-$HADOOP_YARN_HOME/conf}"
 
 # some Java parameters
-# export JAVA_HOME=/home/y/libexec/jdk1.6.0/
 export JAVA_HOME={{ java_home }}
 if [ "$JAVA_HOME" != "" ]; then
   #echo "run java in $JAVA_HOME"

--- a/muckrake/services/templates/hdp/yarn-env.sh
+++ b/muckrake/services/templates/hdp/yarn-env.sh
@@ -20,7 +20,6 @@ export HADOOP_YARN_USER=${HADOOP_YARN_USER:-yarn}
 export YARN_CONF_DIR="${YARN_CONF_DIR:-$HADOOP_YARN_HOME/conf}"
 
 # some Java parameters
-# export JAVA_HOME=/home/y/libexec/jdk1.6.0/
 export JAVA_HOME={{ java_home }}
 if [ "$JAVA_HOME" != "" ]; then
   #echo "run java in $JAVA_HOME"

--- a/vagrant/base.sh
+++ b/vagrant/base.sh
@@ -24,16 +24,16 @@ if [ -z `which javac` ]; then
     apt-get -y update
 
     # Try to share cache. See Vagrantfile for details
-    mkdir -p /var/cache/oracle-jdk6-installer
-    if [ -e "/tmp/oracle-jdk6-installer-cache/" ]; then
-        find /tmp/oracle-jdk6-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk6-installer/ \;
+    mkdir -p /var/cache/oracle-jdk7-installer
+    if [ -e "/tmp/oracle-jdk7-installer-cache/" ]; then
+        find /tmp/oracle-jdk7-installer-cache/ -not -empty -exec cp '{}' /var/cache/oracle-jdk7-installer/ \;
     fi
 
     /bin/echo debconf shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections
-    apt-get -y install oracle-java6-installer oracle-java6-set-default
+    apt-get -y install oracle-java7-installer oracle-java7-set-default
 
-    if [ -e "/tmp/oracle-jdk6-installer-cache/" ]; then
-        cp -R /var/cache/oracle-jdk6-installer/* /tmp/oracle-jdk6-installer-cache
+    if [ -e "/tmp/oracle-jdk7-installer-cache/" ]; then
+        cp -R /var/cache/oracle-jdk7-installer/* /tmp/oracle-jdk7-installer-cache
     fi
 fi
 
@@ -81,5 +81,5 @@ gpg --keyserver pgp.mit.edu --recv-keys B9733A7A07513CAD
 gpg -a --export 07513CAD | apt-key add -
 apt-get update
 apt-get install -y hadoop hadoop-hdfs libhdfs0 hadoop-yarn hadoop-mapreduce hadoop-client openssl
-echo "export JAVA_HOME=/usr/lib/jvm/java-6-oracle" >> /etc/hadoop/conf/hadoop-env.sh
+echo "export JAVA_HOME=/usr/lib/jvm/java-7-oracle" >> /etc/hadoop/conf/hadoop-env.sh
 echo "export HADOOP_CONF_DIR=/mnt" >> /etc/hadoop/conf/hadoop-env.sh


### PR DESCRIPTION
@ewencp minimal change - addresses issue #34 

searched for java 6 references with 
`egrep -r "(jdk\s*6)|(java\s*6)" .`

